### PR TITLE
changed calculator background color 

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Please adhere to this project's [Code_Of_Conduct](https://github.com/Sanket1308/
 | Color             | Hex                                                                |
 | ----------------- | ------------------------------------------------------------------ |
 | Background Color(Light Blue) |  #00ffff |
-| Calculator Container Color(Dark Blue) |#0040ff |
+| Calculator Container Color(Dark Blue) | #0b4e81 |
 | white Color | #ffffff |
 | Button Color(Green shade)  | #00d1a0 |
 | Button Color(Light Pink) | #FFA07A |

--- a/css/style.css
+++ b/css/style.css
@@ -22,7 +22,7 @@
 .calculator{
     height: 500px;
     width: 400px;
-    background-color:rgb(9, 51, 114);
+    background-color:rgb(11, 78, 129);
     margin: 0 auto;
     position: relative;
     
@@ -45,7 +45,7 @@
 .calculator {
   height: 500px;
   width: 400px;
-  background-color: rgb(9, 51, 114);
+  background-color: rgb(11, 78, 129);
   margin: 0 auto;
   position: relative;
 


### PR DESCRIPTION
I changed the calculator background to a lighter one which fits the background theme. I also updated the hex value in the [README.md](https://github.com/Sanket1308/Simple-Calculator/blob/main/README.md). Fixes #30 

Looks like this now:
![image](https://user-images.githubusercontent.com/66525499/193465520-7351a072-de2e-487b-9daf-59a0ac6a08d1.png)
